### PR TITLE
make ShortName optional and bugfix AllowMultiple

### DIFF
--- a/src/CommandLineArgumentsParser/Arguments/Argument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/Argument.cs
@@ -19,9 +19,11 @@ namespace CommandLineParser.Arguments
     /// <include file='..\Doc\CommandLineParser.xml' path='CommandLineParser/Arguments/Argument/*'/>
     public abstract class Argument
     {
-#region property backing fields
+        public const char UnsetShortNameChar = ' ';
 
-        private char _shortName = '_';
+        #region property backing fields
+
+        private char _shortName = UnsetShortNameChar;
 
         private string _longName;
 
@@ -37,9 +39,9 @@ namespace CommandLineParser.Arguments
 
         private FieldArgumentBind? _bind;
 
-#endregion
+        #endregion
 
-#region constructors
+        #region constructors
 
         /// <summary>
         /// Creates new command line argument with a <see cref="ShortName">short name</see>.
@@ -75,7 +77,7 @@ namespace CommandLineParser.Arguments
             ShortName = shortName;
         }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Mark argument optional. 
@@ -106,7 +108,7 @@ namespace CommandLineParser.Arguments
         /// </summary>
         public string Description { get; set; }
 
-        private static readonly char[] BadChars = new char[] { '\r', '\n', ' ', '\t'};
+        private static readonly char[] BadChars = new char[] { '\r', '\n', ' ', '\t' };
 
         /// <summary>
         /// Long name of the argument. Can apear on the command line in --<i>longName</i> format.
@@ -135,10 +137,10 @@ namespace CommandLineParser.Arguments
             get { return _shortName; }
             set
             {
-                if (char.IsWhiteSpace(value))
-                {
-                    throw new FormatException(Messages.EXC_ARG_NOT_ONE_CHAR);
-                }
+                //if (char.IsWhiteSpace(value))
+                //{
+                //    throw new FormatException(Messages.EXC_ARG_NOT_ONE_CHAR);
+                //}
                 _shortName = value;
             }
         }
@@ -178,7 +180,7 @@ namespace CommandLineParser.Arguments
         /// <seealso cref="LongAliases"/>
         public IEnumerable<char> ShortAliases
         {
-            get { return _shortAliases; }                
+            get { return _shortAliases; }
         }
 
         /// <summary>
@@ -194,13 +196,13 @@ namespace CommandLineParser.Arguments
         internal IEnumerable<string> AllAliases
         {
             get { return LongAliases.Concat(ShortAliases.Select(a => a.ToString())); }
-        }        
+        }
 
         /// <summary>
         /// Defines mapping of the value of the argument to a field of another object.
         /// Bound field is updated after the value of the argument is parsed by <see cref="CommandLineParser"/>.
         /// </summary>
-        public FieldArgumentBind ? Bind
+        public FieldArgumentBind? Bind
         {
             get { return _bind; }
             set { _bind = value; }
@@ -211,7 +213,7 @@ namespace CommandLineParser.Arguments
         /// <param name="alias">Short alias of the argument</param>
         /// </summary>
         public void AddAlias(char alias)
-        {            
+        {
             _shortAliases.Add(alias);
         }
 
@@ -262,7 +264,7 @@ namespace CommandLineParser.Arguments
         /// </summary>
         public virtual void Init()
         {
-            Parsed = false; 
+            Parsed = false;
         }
 
         /// <summary>
@@ -286,7 +288,7 @@ namespace CommandLineParser.Arguments
     /// you where you have delcared argument attributes.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    public abstract class ArgumentAttribute: Attribute
+    public abstract class ArgumentAttribute : Attribute
     {
         private readonly Argument _argument;
 
@@ -313,7 +315,7 @@ namespace CommandLineParser.Arguments
             _argument = (Argument)Activator.CreateInstance(underlyingArgumentType, constructorParams);
         }
 
-#region delegated argument members
+        #region delegated argument members
 
         /// <summary>
         /// Description of the argument 
@@ -408,7 +410,7 @@ namespace CommandLineParser.Arguments
             }
         }
 
-#endregion
+        #endregion
 
     }
 }

--- a/src/CommandLineArgumentsParser/CommandLineParser.cs
+++ b/src/CommandLineArgumentsParser/CommandLineParser.cs
@@ -209,7 +209,7 @@ namespace CommandLineParser
             _longNameLookup = new Dictionary<string, Argument>();
             foreach (Argument argument in _arguments)
             {
-                if (argument.ShortName != ' ')
+                if (argument.ShortName != Argument.UnsetShortNameChar)
                 {
                     _shortNameLookup.Add(argument.ShortName, argument);
                 }
@@ -299,7 +299,7 @@ namespace CommandLineParser
 
             PerformMandatoryArgumentsCheck();
             PerformCertificationCheck();
-            ParsingSucceeded = true; 
+            ParsingSucceeded = true;
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace CommandLineParser
                     }
                 }
             }
-        }        
+        }
 
         private void ExpandValueArgumentsWithEqualSigns(IList<string> argsList)
         {
@@ -561,7 +561,7 @@ namespace CommandLineParser
                                     {
                                         argsList.Insert(i, singleValue);
                                         i++;
-                                    }                                    
+                                    }
                                 }
                                 i--;
                             }
@@ -570,7 +570,7 @@ namespace CommandLineParser
                                 argsList.Insert(i, argNameWithSep);
                                 i++;
                                 argsList.Insert(i, argValue);
-                            }                            
+                            }
                         }
                     }
                 }
@@ -620,7 +620,7 @@ namespace CommandLineParser
             {
                 outputStream.Write("\t");
                 bool comma = false;
-                if (argument.ShortName != ' ')
+                if (argument.ShortName != Argument.UnsetShortNameChar)
                 {
                     outputStream.Write("-" + argument.ShortName);
                     comma = true;

--- a/src/CommandLineArgumentsParser/project.json
+++ b/src/CommandLineArgumentsParser/project.json
@@ -21,6 +21,7 @@
     },
 
     "buildOptions": {
+      "xmlDoc": true
     },
 
     "frameworks": {

--- a/src/ParserTest/Program.cs
+++ b/src/ParserTest/Program.cs
@@ -44,6 +44,11 @@ namespace ParserTest
 
         [DirectoryArgument('d', "directory", Description = "Input directory", DirectoryMustExist = false)]
         public DirectoryInfo InputDirectory;
+
+        [ValueArgument(typeof(string), Argument.UnsetShortNameChar, "types", Optional = true, AllowMultiple = true,
+            Description = "The file-types to process")]
+        public string[] FileTypes { get; set; }
+
     }
 #pragma warning restore CS0649
 
@@ -59,7 +64,7 @@ namespace ParserTest
             parser.ShowUsageHeader = "This is an interesting command";
             parser.ShowUsageFooter = "And that is all";
             parser.ExtractArgumentAttributes(p);
-            parser.Certifications.Add(new DistinctGroupsCertification("d", "color") { Description = "This is this"});
+            parser.Certifications.Add(new DistinctGroupsCertification("d", "color") { Description = "This is this" });
 
             var examples = new List<string[]>();
             examples.Add(new string[0]); //No arguments passed
@@ -72,6 +77,7 @@ namespace ParserTest
             examples.Add(new[] { "/d" }); // error, missing value
             examples.Add(new[] { "/d", "C:\\Input" });
             examples.Add(new[] { "file1", "file2" });
+            examples.Add(new[] { "--types", "png", "jpg", "pdf", "/show" });
 
             foreach (string[] arguments in examples)
             {
@@ -126,6 +132,7 @@ namespace ParserTest
             parser.ShowParsedArguments();
             Console.WriteLine("RESULT: OK");
             Console.WriteLine();
+            Console.ReadKey();
         }
     }
 }


### PR DESCRIPTION
- make ShortName optional (use Argument.UnsetShortNameChar constant)
- bugfix: parse AllowMultiple correctly