### PR TITLE
Parsing fails when there is equal sign (=) in argument

### DIFF
--- a/src/CommandLineArgumentsParser/CommandLineParser.cs
+++ b/src/CommandLineArgumentsParser/CommandLineParser.cs
@@ -529,8 +529,8 @@ namespace CommandLineParser
                 for (int i = 0; i < argsList.Count; i++)
                 {
                     string arg = argsList[i];
-
-                    Regex r = new Regex("(.*)=(.*)");
+				
+                    Regex r = new Regex("([^=]*)=(.*)");
                     if (AcceptEqualSignSyntaxForValueArguments && r.IsMatch(arg))
                     {
                         Match m = r.Match(arg);

--- a/src/Tests/Tests.EqualSignSyntax.cs
+++ b/src/Tests/Tests.EqualSignSyntax.cs
@@ -199,5 +199,14 @@ namespace Tests
             // ASSERT
             Assert.Equal(new List<int>(), lines.Values);
         }
+         
+        [Fact]
+        public void EqualSignSyntax_ShouldSplitFromFirstEqualSignFound()
+        {
+            string[] args = new[] { "--level=ABCDEFGHI=+FTRWEQASD" };
+
+            var commandLineParser = InitEqualSignSyntax();
+            commandLineParser.ParseCommandLine(args);
+        }
     }
 }


### PR DESCRIPTION
Issue: while parsing "--text=VxSSSZ0QN2ViZgvcBfkttoiV2gwQ8XcOGp3Mx4ud6vQ=" (note there are two = signs here)

Regex would match:
name = "--text=VxSSSZ0QN2ViZgvcBfkttoiV2gwQ8XcOGp3Mx4ud6vQ"
arg = ""//blank

now regex will match:
 name =  "--text"
 arg = "VxSSSZ0QN2ViZgvcBfkttoiV2gwQ8XcOGp3Mx4ud6vQ="

Added a unit test as well.